### PR TITLE
Update to node 5.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y build-essential g++ curl libssl-dev apache2-utils git lib
 
 # ------------------------------------------------------------------------------
 # Install Node.js
-RUN curl -sL https://deb.nodesource.com/setup | bash -
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
 RUN apt-get install -y nodejs
     
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Cloud9 is known to work on node 5. I've also tested this change in a locally built docker container it works great.
